### PR TITLE
Ошибка в логике обработки сообщений в app.py

### DIFF
--- a/core/fastapi_app/app.py
+++ b/core/fastapi_app/app.py
@@ -37,7 +37,7 @@ async def websocket_endpoint(websocket: WebSocket):  # в будущем авт�
             action = parse_obj_as(ActionDTO, data)
             if actions_map.__contains__(action.name):
                 await actions_map[action.name](action.body, websocket)
-            return
+
     except WebSocketDisconnect:
         websocket_manager.disconnect(websocket)
 


### PR DESCRIPTION
Cтрока return внутри цикла while True. Эта строка завершает цикл после получения первого сообщения, что предотвращает обработку последующих сообщений.

Удалим return, чтобы сервер продолжал обрабатывать сообщения в цикле